### PR TITLE
fix: handlebars 4.7.9 override (Dependabot batch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@continuonai/rcan-ts",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@continuonai/rcan-ts",
-      "version": "1.2.2",
+      "version": "1.3.0",
       "license": "MIT",
       "dependencies": {
         "@noble/post-quantum": "^0.5.4"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "overrides": {
+    "handlebars": "^4.7.9"
+  },
   "dependencies": {
     "@noble/post-quantum": "^0.5.4"
   }


### PR DESCRIPTION
## Summary

- Adds an `overrides` entry in `package.json` pinning `handlebars` to `^4.7.9`
- Resolves 7 Dependabot alerts (1 critical, 3 high, 2 moderate, 1 low) that surface through `ts-jest`'s transitive dependency chain
- `npm install` confirms **0 vulnerabilities** after the override is applied

## Background

`ts-jest` (a devDependency) pulls in an older version of `handlebars` which carries well-known prototype pollution and RCE vulnerabilities (CVE-2021-23369, CVE-2021-23383, and related). Because these are devDependencies they don't affect the published package at runtime, but they do affect CI environments and developer machines and trigger Dependabot alerts on the repo.

The `npm` `overrides` field forces all nested resolutions of `handlebars` to `^4.7.9`, the first fully-patched release.

## Test plan

- [x] `npm install` completes with 0 vulnerabilities
- [x] `npm test` — all **579 tests pass** across **31 test suites** (no regressions)
- [ ] Confirm Dependabot alerts are dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)