### PR TITLE
docs: Plan 2 Phase 5 PR 2C — retire hardcoded RCAN versions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@
 - `validateLoaForScope()` — Level of Assurance policy enforcement
 - Federation, consent, multimodal, replay, and delegation support
 
-**Version**: 0.8.0 | **Spec**: RCAN v1.9.0 | **Runtime**: Node.js 18+ | **Tests**: 447 passing
+**Version**: 0.8.0 | **Spec**: see [rcan.dev/compatibility](https://rcan.dev/compatibility) | **Runtime**: Node.js 18+ | **Tests**: 447 passing
 
 ## Repository Layout
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # rcan-ts
 
-**TypeScript SDK for the [RCAN protocol](https://rcan.dev/spec/) v3.0.** Build robots that communicate securely, audit every action, and enforce safety gates — in Node.js or the browser.
+**TypeScript SDK for the [RCAN protocol](https://rcan.dev/spec/).** Build robots that communicate securely, audit every action, and enforce safety gates — in Node.js or the browser. Pinned protocol version: see the [live compatibility matrix](https://rcan.dev/compatibility).
 
 [![npm version](https://img.shields.io/npm/v/rcan-ts.svg)](https://www.npmjs.com/package/rcan-ts)
-[![RCAN Spec](https://img.shields.io/badge/RCAN-v3.0-blue)](https://rcan.dev/spec/)
+[![RCAN Spec](https://img.shields.io/badge/RCAN-live%20matrix-blue)](https://rcan.dev/compatibility)
 [![CI](https://github.com/continuonai/rcan-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/continuonai/rcan-ts/actions)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Node](https://img.shields.io/badge/node-18%2B-green)](https://nodejs.org)
@@ -150,7 +150,7 @@ console.log(node.operator);  // "Boston Dynamics, Inc."
 
 ## Spec Compliance
 
-Implements [RCAN v1.6](https://rcan.dev/spec/) — 405 tests, 0 skipped.
+Implements [the RCAN protocol](https://rcan.dev/compatibility) — 405 tests, 0 skipped. See the [live compatibility matrix](https://rcan.dev/compatibility) for the pinned version this SDK targets.
 
 API surface is intentionally identical to rcan-py: `RobotURI`, `RCANMessage`, `ConfidenceGate`, `HiTLGate`, `AuditChain`, and `validateConfig` work the same way in both languages.
 


### PR DESCRIPTION
## Summary

Phase 5 PR 2C of Plan 2 (Documentation Accuracy Pass). Mirror of rcan-py PR #56.

- README badge URL: \`RCAN-v3.0\` → \`RCAN-live%20matrix\` linking to /compatibility
- README §"Spec Compliance": \`Implements [RCAN v1.6]\` → matrix link
- CLAUDE.md preamble: \`Spec: RCAN v1.9.0\` → matrix link
- README opening sentence: dropped trailing \` v3.0\` (regex-blind-spot)

\`forbidden-phrase-lint\` runs clean (0 hits, exit 0).

## Test plan

- [ ] CI green
- [ ] No surface implies a frozen RCAN version is canonical

Refs spec §8 + §10.