### PR TITLE
chore(ci): bump emit-version-tuple to v3.2.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Strip leading v from tag
         run: echo "VALUE=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-ts
           ran: ${{ secrets.RCAN_TS_RELEASE_RAN }}
@@ -136,7 +136,7 @@ jobs:
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-ts
           ran: ${{ secrets.RCAN_TS_RELEASE_RAN }}


### PR DESCRIPTION
## Summary
- Bump `continuonai/rcan-spec/.github/actions/emit-version-tuple` pin from v3.2.0 to v3.2.3 (publish.yml, both publish + backfill jobs).
- v3.2.3 (rcan-spec [PR #209](https://github.com/continuonai/rcan-spec/pull/209), `feb92cb`) adds `--repo "${{ github.repository }}"` to `gh release upload`, fixing the `fatal: not a git repository` failure in checkout-less publish jobs.

## Test plan
- [ ] CI green on this PR
- [ ] Next rcan-ts release tag: emit-version-tuple step exits 0 and attaches the signed envelope to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)