### PR TITLE
docs(claude-md): bump CLAUDE.md version refs (Plan 9 carryover)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,7 @@ rcan-ts/
 ├── src/
 │   ├── message.ts      # RCANMessage class, MessageType enum, validation
 │   ├── identity.ts     # LevelOfAssurance, LoaPolicy, validateLoaForScope
-│   ├── version.ts      # SPEC_VERSION = "1.6.1", SDK_VERSION = "0.6.0"
+│   ├── version.ts      # SPEC_VERSION = "3.2", SDK_VERSION = "3.4.2"
 │   ├── uri.ts          # RobotURI — parse/validate rcan:// URIs
 │   ├── federation.ts   # Federation sync and peer validation
 │   ├── consent.ts      # Cross-robot consent protocol
@@ -32,18 +32,20 @@ rcan-ts/
 │   ├── identity.test.ts   # LoA enforcement, scope validation
 │   ├── federation.test.ts # Federation protocol tests
 │   └── ...                # 25 test suites
-├── package.json        # version: "0.6.0"
+├── package.json        # name: "rcan-ts", version: "3.4.2"
 └── tsconfig.json
 ```
 
 ## Key Constants
 
 ```typescript
-import { MessageType, SPEC_VERSION, SDK_VERSION } from 'rcan';
+import { MessageType, SPEC_VERSION, SDK_VERSION } from 'rcan-ts';
 
-SPEC_VERSION  // "1.6.1" — tracks current stable spec version
-SDK_VERSION   // "0.6.0"
+SPEC_VERSION  // "3.2" — tracks current stable spec version
+SDK_VERSION   // "3.4.2"
 ```
+
+The published npm package is `rcan-ts` (NOT `@continuonai/rcan`, which 404s).
 
 ## Running Tests
 


### PR DESCRIPTION
## Summary

Plan 9 [lessons-learned](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/lessons-learned/2026-05-08-plan-9-execution.md) open question §4 (cross-repo CLAUDE.md drift sweep). 4 stale lines + 1 wrong import in CLAUDE.md.

## Diff

| Line | Before | After |
|---|---|---|
| 23 | `version.ts # SPEC_VERSION = "1.6.1", SDK_VERSION = "0.6.0"` | `# SPEC_VERSION = "3.2", SDK_VERSION = "3.4.2"` |
| 35 | `package.json # version: "0.6.0"` | `# name: "rcan-ts", version: "3.4.2"` |
| 42 | `import ... from 'rcan';` | `import ... from 'rcan-ts';` |
| 44-45 | `SPEC_VERSION "1.6.1"` / `SDK_VERSION "0.6.0"` | `"3.2"` / `"3.4.2"` |

Plus a one-liner clarifying the npm package name confusion (`rcan-ts` is published; `@continuonai/rcan` returns 404 — same bug fixed in [opencastor-client#128 F-OCC-08](https://github.com/craigm26/opencastor-client/pull/128)).

## Verifies against

- `src/version.ts` → `SPEC_VERSION = "3.2"`
- `package.json` → `name = "rcan-ts"`, `version = "3.4.2"`
- `curl -s https://registry.npmjs.org/rcan-ts | jq -r '."dist-tags".latest'` → `3.4.2`
- `curl -s https://registry.npmjs.org/@continuonai%2Frcan` → `{"error":"Not found"}`

## Sister PRs (same drift class)

- `craigm26/opencastor-ops` master `f9bfd1b` (direct commit)
- [craigm26/opencastor-client#132](https://github.com/craigm26/opencastor-client/pull/132)
- [craigm26/OpenCastor#896](https://github.com/craigm26/OpenCastor/pull/896)
- continuonai/rcan-py PR (parallel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)