### PR TITLE
chore: move rcan-ts to RobotRegistryFoundation + OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Strip leading v from tag
         run: echo "VALUE=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
+      - uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-ts
           ran: ${{ secrets.RCAN_TS_RELEASE_RAN }}
@@ -92,7 +92,7 @@ jobs:
 
   npm-publish:
     # OIDC Trusted Publishing — requires a trusted publisher registered on npmjs.com
-    # for the rcan-ts package (org continuonai, repo rcan-ts, workflow publish.yml).
+    # for the rcan-ts package (org RobotRegistryFoundation, repo rcan-ts, workflow publish.yml).
     # Trigger via Actions → Release → Run workflow → publish_npm=true.
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_npm == 'true'
     needs: build-and-test
@@ -140,7 +140,7 @@ jobs:
               --generate-notes
           fi
 
-      - uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
+      - uses: RobotRegistryFoundation/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: rcan-ts
           ran: ${{ secrets.RCAN_TS_RELEASE_RAN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       publish_npm:
-        description: "Publish to npm (requires NPM_TOKEN secret)"
+        description: "Publish to npm (OIDC trusted publishing — no NPM_TOKEN needed)"
         required: true
         type: boolean
         default: false
@@ -91,24 +91,28 @@ jobs:
           release_tag: ${{ github.ref_name }}
 
   npm-publish:
-    # Manual-only until NPM_TOKEN is configured for continuonai/rcan-ts.
+    # OIDC Trusted Publishing — requires a trusted publisher registered on npmjs.com
+    # for the rcan-ts package (org continuonai, repo rcan-ts, workflow publish.yml).
     # Trigger via Actions → Release → Run workflow → publish_npm=true.
     if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_npm == 'true'
     needs: build-and-test
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # OIDC: npm Trusted Publishing (no NPM_TOKEN needed)
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22            # npm OIDC requires Node >= 22.14.0
           registry-url: https://registry.npmjs.org
           cache: npm
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest   # OIDC requires npm CLI >= 11.5.1
       - run: npm ci
       - run: npm run build
-      - name: Publish to npm
+      - name: Publish to npm (OIDC — provenance is automatic)
         run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   backfill-emit:
     name: Emit signed version-tuple envelope (backfill)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# rcan-ts — stewarded by the Robot Registry Foundation.
+# Replace with an @RobotRegistryFoundation/<team> once a maintainers team exists.
+* @craigm26

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,13 @@
+# Contributing to rcan-ts
+
+`rcan-ts` is the official TypeScript SDK for **RCAN**, an open standard
+stewarded by the
+[Robot Registry Foundation](https://github.com/RobotRegistryFoundation).
+
+- **SDK issues / PRs:** welcome here.
+- **Protocol / normative spec changes:** open them in
+  [`rcan-spec`](https://github.com/RobotRegistryFoundation/rcan-spec) — see its
+  governance process.
+- **Dev setup & tests:** `npm install` then `npm test` (see [`CLAUDE.md`](CLAUDE.md)).
+
+`MessageType` integers MUST stay in sync with `rcan-py`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![npm version](https://img.shields.io/npm/v/rcan-ts.svg)](https://www.npmjs.com/package/rcan-ts)
 [![RCAN Spec](https://img.shields.io/badge/RCAN-live%20matrix-blue)](https://rcan.dev/compatibility)
-[![CI](https://github.com/continuonai/rcan-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/continuonai/rcan-ts/actions)
+[![CI](https://github.com/RobotRegistryFoundation/rcan-ts/actions/workflows/ci.yml/badge.svg)](https://github.com/RobotRegistryFoundation/rcan-ts/actions)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Node](https://img.shields.io/badge/node-18%2B-green)](https://nodejs.org)
 
@@ -17,8 +17,8 @@ This repo is the **TypeScript SDK** layer — the library any JS/TS planner, gat
 | **Declaration** | [ROBOT.md](https://github.com/RobotRegistryFoundation/robot-md) | The file a robot ships at its root. YAML frontmatter + markdown prose. Spec + Python CLI. |
 | **Agent bridge** | [robot-md-mcp](https://github.com/RobotRegistryFoundation/robot-md-mcp) | MCP server that exposes a `ROBOT.md` to Claude Code, Cursor, Zed, Gemini CLI — any MCP-aware agent. |
 | **Wire protocol** | [RCAN](https://rcan.dev/spec/) | How robots, gateways, and planners talk. Signed envelopes, LoA enforcement, PQC crypto. Think HTTP for robots. |
-| **Python SDK** | [rcan-py](https://github.com/continuonai/rcan-py) | `pip install rcan` — `RCANMessage`, `RobotURI`, `ConfidenceGate`, `HiTLGate`, `AuditChain`, `RegistryClient`. |
-| **TypeScript SDK** ← *this* | [rcan-ts](https://github.com/continuonai/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
+| **Python SDK** | [rcan-py](https://github.com/RobotRegistryFoundation/rcan-py) | `pip install rcan` — `RCANMessage`, `RobotURI`, `ConfidenceGate`, `HiTLGate`, `AuditChain`, `RegistryClient`. |
+| **TypeScript SDK** ← *this* | [rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts) | `npm install rcan-ts` — same API surface for Node + browser. |
 | **Registry** | [Robot Registry Foundation](https://robotregistryfoundation.org) | Permanent RRN identities. Public resolver at `/r/<rrn>`. Like ICANN for robots. |
 | **Reference runtime** | [OpenCastor](https://github.com/craigm26/OpenCastor) | Open-source robot runtime — connects LLM brains to hardware bodies. One implementation of RCAN. |
 
@@ -158,9 +158,9 @@ API surface is intentionally identical to rcan-py: `RobotURI`, `RCANMessage`, `C
 
 | Package | Version | Purpose |
 |---|---|---|
-| [rcan-py](https://github.com/continuonai/rcan-py) | v0.6.0 | Python SDK |
+| [rcan-py](https://github.com/RobotRegistryFoundation/rcan-py) | v0.6.0 | Python SDK |
 | **rcan-ts** (this) | v0.6.0 | TypeScript SDK |
-| [rcan-spec](https://github.com/continuonai/rcan-spec) | v1.6.0 | Protocol spec |
+| [rcan-spec](https://github.com/RobotRegistryFoundation/rcan-spec) | v1.6.0 | Protocol spec |
 | [ROBOT.md](https://robotmd.dev) | v0.1.0 | Single-file robot manifest |
 | [OpenCastor](https://github.com/craigm26/OpenCastor) | v2026.3.17.1 | Robot runtime (reference impl) |
 | [RRF](https://robotregistryfoundation.org) | v1.6.0 | Robot identity registry |
@@ -169,9 +169,9 @@ API surface is intentionally identical to rcan-py: `RobotURI`, `RCANMessage`, `C
 
 ## Contributing
 
-Issues and PRs welcome at [github.com/continuonai/rcan-ts](https://github.com/continuonai/rcan-ts).
+Issues and PRs welcome at [github.com/RobotRegistryFoundation/rcan-ts](https://github.com/RobotRegistryFoundation/rcan-ts).
 
-Spec discussions: [github.com/continuonai/rcan-spec/issues](https://github.com/continuonai/rcan-spec/issues)
+Spec discussions: [github.com/RobotRegistryFoundation/rcan-spec/issues](https://github.com/RobotRegistryFoundation/rcan-spec/issues)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -176,3 +176,7 @@ Spec discussions: [github.com/RobotRegistryFoundation/rcan-spec/issues](https://
 ## License
 
 MIT © Craig Merry
+
+---
+
+> **Stewarded by the [Robot Registry Foundation](https://github.com/RobotRegistryFoundation).** RCAN is an open standard; issues and PRs welcome. See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/continuonai/rcan-ts.git"
+    "url": "git+https://github.com/RobotRegistryFoundation/rcan-ts.git"
   },
   "devDependencies": {
     "@types/jest": "^29.5.0",
@@ -98,7 +98,7 @@
     "test": "tests"
   },
   "bugs": {
-    "url": "https://github.com/continuonai/rcan-ts/issues"
+    "url": "https://github.com/RobotRegistryFoundation/rcan-ts/issues"
   },
-  "homepage": "https://github.com/continuonai/rcan-ts#readme"
+  "homepage": "https://github.com/RobotRegistryFoundation/rcan-ts#readme"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@
  * Robot Communication and Accountability Network
  *
  * @see https://rcan.dev
- * @see https://github.com/continuonai/rcan-ts
+ * @see https://github.com/RobotRegistryFoundation/rcan-ts
  */
 
 export { RobotURI, RobotURIError } from "./address.js";


### PR DESCRIPTION
Part of moving the RCAN trio from `continuonai` to the **Robot Registry
Foundation**. The published npm package stays `rcan-ts`; only the source home and
CI trust change.

Changes:
- `ci: migrate npm publishing to OIDC trusted publishing` — `id-token: write`,
  Node 22 + npm ≥11.5.1, drop `NPM_TOKEN`, automatic provenance. (Requires a
  trusted publisher on npmjs.com for `RobotRegistryFoundation/rcan-ts`, no env.)
- `chore(ci)`: re-point `publish.yml` (`emit-version-tuple` action + OIDC note) at
  the new owner.
- `docs`: `package.json` repository/bugs/homepage, `src/index.ts`, README
  re-pointed.
- Governance: `CODEOWNERS`, `CONTRIBUTING.md`, README stewardship note.

`CLAUDE.md`'s historical `@continuonai/rcan` (the 404 example) and the CHANGELOG
were left intact. Token retirement (deleting `NPM_TOKEN`) is a separate follow-up.
